### PR TITLE
Fix problem with muliple tags

### DIFF
--- a/pr0gramm/api.py
+++ b/pr0gramm/api.py
@@ -434,7 +434,7 @@ class Api:
             DeprecationWarning
         )
 
-        tags = tags.replace(" ", "+")
+        #tags = tags.replace(" ", "+")
         params = {'flags': flag, 'promoted': promoted, 'tags': tags}
 
         if older != -1:
@@ -477,7 +477,7 @@ class Api:
                  json reply from api
         """
 
-        tags = tags.replace(" ", "+")
+        #tags = tags.replace(" ", "+")
         params = {"flags": flag, "promoted": promoted, "tags": tags}
 
         params = self.__set_older_param(params, older, item)


### PR DESCRIPTION
Die Pr0gramm API wurde anscheinend aktualisiert. Wenn man versucht mehere Tags mit "+" mit einander zu verbinden bekommt man keine Posts zurück.
Beispiel:
Mit "schmuserkadser blussi" als Tags wurden diese zu "schmuserkadser+blussi" welche im Cache als 
"stream: new:2:tschmuserkadser+blussi:n-1" angezeigt wird. Und somit keine Resultate liefert.
Ohne das "+" da zwischen funktioniert es einwandfrei und der Cache zeigt auch  "stream: new:2:tschmuserkadser blussi:n-1" an, was mittlerweile legal scheint.